### PR TITLE
片手同時押しの「・」「／」修正

### DIFF
--- a/jp-keyboard-layout.json
+++ b/jp-keyboard-layout.json
@@ -1654,7 +1654,16 @@
           "conditions": [
             {"type": "input_source_if","input_sources": [{"language": "ja"}]}
           ],
-          "from": {"simultaneous": [{"key_code": "r"},{"key_code": "f"},{"key_code": "g"}]},
+          "from": {"simultaneous": [{"key_code": "r"},{"key_code": "f"}]},
+          "to": [{"key_code": "slash", "repeat": false}]
+        },
+
+        {
+          "type": "basic",
+          "conditions": [
+            {"type": "input_source_if","input_sources": [{"language": "ja"}]}
+          ],
+          "from": {"simultaneous": [{"key_code": "r"},{"key_code": "g"}]},
           "to": [{"key_code": "slash", "repeat": false}]
         },
 
@@ -1682,7 +1691,16 @@
           "conditions": [
             {"type": "input_source_if","input_sources": [{"language": "ja"}]}
           ],
-          "from": {"simultaneous": [{"key_code": "u"},{"key_code": "h"},{"key_code": "j"}]},
+          "from": {"simultaneous": [{"key_code": "u"},{"key_code": "h"}]},
+          "to": [{"key_code": "slash", "modifiers": ["left_option"], "repeat": false}]
+        },
+
+        {
+          "type": "basic",
+          "conditions": [
+            {"type": "input_source_if","input_sources": [{"language": "ja"}]}
+          ],
+          "from": {"simultaneous": [{"key_code": "u"},{"key_code": "j"}]},
           "to": [{"key_code": "slash", "modifiers": ["left_option"], "repeat": false}]
         },
 


### PR DESCRIPTION
片手同時押しで入力する「・」と「／」が入力できない不具合を修正。
「・」は、R+FまたはR+Gで入力可能に、
「／」は、U+HまたはU+Jで入力可能になります。